### PR TITLE
Update bash_env

### DIFF
--- a/bash_env
+++ b/bash_env
@@ -1,8 +1,10 @@
 # defaults
 if  [ -x "$(command -v nvim)" ]; then
     export EDITOR=nvim
+    export VISUAL=nvim
 else
     export EDITOR=vim
+    export VISUAL=vim
 fi
 export CLICOLOR=TRUE
 # export TERM="xterm-256color" # not recommended by tmux


### PR DESCRIPTION
According to https://unix.stackexchange.com/questions/73484/how-can-i-set-vi-as-my-default-editor-in-unix, $VISUAL is also recommended to set.

Has some DRY violations but who gives a shit. Another solution would be to do `export VISUAL=$EDITOR` after the if-clause, it's up to you 😂 